### PR TITLE
Fix Null Pointer Issue for Search Bars

### DIFF
--- a/NWN.Toolbox/src/Features/ToolWindows/ObjectTools/CreatorWindowController.cs
+++ b/NWN.Toolbox/src/Features/ToolWindows/ObjectTools/CreatorWindowController.cs
@@ -24,6 +24,7 @@ namespace Jorteck.Toolbox.Features.ToolWindows
 
     public override void Init()
     {
+      Token.SetBindValue(View.Search, string.Empty);
       Token.SetBindValue(View.BlueprintType, (int)BlueprintObjectType.Creature);
       Token.SetBindValue(View.CreateButtonEnabled, false);
       RefreshCreatorList();

--- a/NWN.Toolbox/src/Features/ToolWindows/Toolbox/ToolboxWindowController.cs
+++ b/NWN.Toolbox/src/Features/ToolWindows/Toolbox/ToolboxWindowController.cs
@@ -40,6 +40,8 @@ namespace Jorteck.Toolbox.Features.ToolWindows
         toolboxWindows = AvailableWindows.Value.Where(view => view.ListInToolbox);
       }
 
+      Token.SetBindValue(View.Search, string.Empty);
+
       allWindows = toolboxWindows.Where(view => view.Title != null)
         .OrderBy(view => view.Title)
         .ToList();


### PR DESCRIPTION
This PR sets the initial value of the Search bar bindings to an empty string, fixing two issues: An issue where windows would not show in the tool menu, and an issue where objects could not be spawned using the enhanced creator due to the list being empty.